### PR TITLE
FEAT(PREMIUM)-CHECKOUT

### DIFF
--- a/frontend/src/Router.js
+++ b/frontend/src/Router.js
@@ -77,9 +77,21 @@ const routes = [
         meta: { analytics: false }
     },
     {
-        path: '/premium/Checkout',
+        path: '/premium/checkout',
         name: 'PremiumCheckout',
-        component: () => import('./views/premium/Checkout.vue'),
+        component: () => import('@/views/premium/Checkout.vue'),
+        meta: { analytics: true }
+    },
+    {
+        path: '/premium/success',
+        name: 'PremiumSuccess',
+        component: () => import('./views/premium/Success.vue'),
+        meta: { analytics: true }
+    },
+    {
+        path: '/premium/error',
+        name: 'PremiumError',
+        component: () => import('./views/premium/Error.vue'),
         meta: { analytics: true }
     }
 ]

--- a/frontend/src/components/premium/PlanSelector.vue
+++ b/frontend/src/components/premium/PlanSelector.vue
@@ -1,0 +1,34 @@
+<template>
+    <section class="row g-3">
+        <div class="col-12 col-md-6">
+        <div class="card h-100">
+            <div class="card-body d-flex flex-column">
+            <h2 class="h5 mb-1">Mensual</h2>
+            <div class="fs-4 fw-bold">U$s2.99/mo</div>
+            <p class="text-muted mt-2">Pagás mes a mes. Cancelás cuando quieras.</p>
+            <button class="btn btn-primary mt-auto" @click="$emit('select', 1)">
+                Elegir Mensual
+            </button>
+            </div>
+        </div>
+        </div>
+
+        <div class="col-12 col-md-6">
+        <div class="card h-100 border-primary">
+            <div class="card-body d-flex flex-column">
+            <div class="small text-primary mb-1">Mejor precio</div>
+            <h2 class="h5 mb-1">Anual</h2>
+            <div class="fs-4 fw-bold">U$s29.99/yr</div>
+            <p class="text-muted mt-2">Un solo pago anual. Acceso Premium todo el año.</p>
+            <button class="btn btn-outline-primary mt-auto" @click="$emit('select', 2)">
+                Elegir Anual
+            </button>
+            </div>
+        </div>
+        </div>
+    </section>
+</template>
+
+<script setup>
+defineEmits(['select'])
+</script>

--- a/frontend/src/components/premium/Planes.vue
+++ b/frontend/src/components/premium/Planes.vue
@@ -10,7 +10,7 @@
                 :price="$t('premium.planes.paquetes[' + item.id + '].price')"
                 :texto="$t('premium.planes.paquetes[' + item.id + '].description')"
                 :texto-btn="$t('premium.planes.paquetes[' + item.id + '].ctaBtn')"
-                :btn-url="item.id === 0 ? 'https://play.google.com/store/apps/details?id=com.sugarcoachpremium&hl=es_AR&pli=1' : '/premium/checkout?plan=' + item.id"
+                :btn-url="item.id === 0 ? 'https://play.google.com/store/apps/details?id=com.sugarcoachpremium&hl=es_AR&pli=1' : '/premium/checkout'"
                 :paqueteId="item.id"
                 :beneficios="item.beneficios"
                 from="premium"

--- a/frontend/src/views/premium/Checkout.vue
+++ b/frontend/src/views/premium/Checkout.vue
@@ -1,11 +1,66 @@
 <template>
-    <section class="container py-5">
-        <h1>Checkout Premium</h1>
-        <p class="lead">Plan elegido: {{ plan }}</p>
-    </section>
+    <main class="container py-5">
+        <h1 class="mb-4">Checkout Premium</h1>
+
+        <!-- Caso sin plan -->
+        <div v-if="!plan">
+        <PlanSelector @select="goWithPlan" />
+        </div>
+
+        <!-- Caso con plan -->
+        <div v-else class="card">
+        <div class="card-body">
+            <p class="lead mb-2">Plan elegido: <strong>{{ planLabel }}</strong></p>
+            <p class="text-muted small mb-3">Podés cambiar tu plan antes de confirmar el pago.</p>
+
+            <div class="d-flex gap-2 flex-wrap">
+            <button class="btn btn-secondary" @click="clearPlan">Cambiar plan</button>
+            <button class="btn btn-primary" @click="proceed">Continuar</button>
+            <button class="btn btn-outline-success" @click="simulateSuccess">Simular Success</button>
+            <button class="btn btn-outline-danger" @click="simulateError">Simular Error</button>
+            </div>
+        </div>
+        </div>
+    </main>
 </template>
 
 <script setup>
-import { useRoute } from 'vue-router'
-const plan = useRoute().query.plan ?? '1'
+    import { computed } from 'vue'
+    import { useRoute, useRouter } from 'vue-router'
+    import PlanSelector from '@/components/premium/PlanSelector.vue'
+
+    const route = useRoute()
+    const router = useRouter()
+
+    const plan = computed(() => {
+        const p = route.query.plan
+        if (p === '1' || p === '2') return p
+        return null
+    })
+
+    const planLabel = computed(() => {
+        if (plan.value === '1') return 'Mensual – U$s2.99/mo'
+        if (plan.value === '2') return 'Anual – U$s29.99/yr'
+        return ''
+    })
+
+    function goWithPlan(p) {
+        router.replace({ path: '/premium/checkout', query: { plan: String(p) } })
+    }
+
+    function clearPlan() {
+        router.replace({ path: '/premium/checkout' })
+    }
+
+    function proceed() {
+        router.push('/premium/success')
+    }
+
+    function simulateSuccess() {
+        router.push('/premium/success')
+    }
+
+    function simulateError() {
+        router.push('/premium/error')
+    }
 </script>

--- a/frontend/src/views/premium/Error.vue
+++ b/frontend/src/views/premium/Error.vue
@@ -1,0 +1,14 @@
+<template>
+    <main class="container my-5 text-center">
+        <div class="card border-danger">
+        <div class="card-body">
+            <h1 class="h3 text-danger mb-3">Ocurrió un error con tu suscripción</h1>
+            <p class="mb-3">Tu pago no pudo completarse. Por favor intentá de nuevo.</p>
+            <router-link to="/premium/checkout" class="btn btn-danger">Volver al checkout</router-link>
+        </div>
+        </div>
+    </main>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/premium/Success.vue
+++ b/frontend/src/views/premium/Success.vue
@@ -1,0 +1,14 @@
+<template>
+    <main class="container my-5 text-center">
+        <div class="card border-success">
+        <div class="card-body">
+            <h1 class="h3 text-success mb-3">¡Gracias por suscribirte a Premium!</h1>
+            <p class="mb-3">Tu cuenta ya tiene acceso a todas las funciones exclusivas.</p>
+            <router-link to="/" class="btn btn-success">Ir al inicio</router-link>
+        </div>
+        </div>
+    </main>
+</template>
+
+<script setup>
+</script>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,24 +1,13 @@
+import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
 })
-
-// import { fileURLToPath, URL } from 'node:url'
-
-// import { defineConfig } from 'vite'
-// import vue from '@vitejs/plugin-vue'
-
-// // https://vitejs.dev/config/
-// export default defineConfig({
-//   plugins: [
-//     vue(),
-//   ],
-//   resolve: {
-//     alias: {
-//       '@': fileURLToPath(new URL('./src', import.meta.url))
-//     }
-//   }
-// })


### PR DESCRIPTION
- En frontend/vite.config.js: Se descomentó el bloque de configuración con alias y se eliminó la versión mínima. Ahora se activa el alias @ apuntando a src.
- En src/views/premium/Checkout.vue: Se reemplazó casi por completo el archivo. Se agregó la lógica para mostrar selector cuando no hay query, mostrar detalle del plan cuando existe plan=1 o plan=2, y se incluyeron botones para cambiar plan, continuar, simular success y simular error. Import actualizado con alias @.
- En src/components/premium/PlanSelector.vue: Se creó archivo nuevo con cards de planes Mensual y Anual, emitiendo evento select.
- En src/views/premium/Success.vue: Se creó un archivo nuevo con vista mínima de confirmación de suscripción premium y botón para volver al inicio.
- En src/views/premium/Error.vue: Se creó un archivo nuevo con vista mínima de error en suscripción y botón para volver al checkout.
- En src/router/Router.js: Se agregó ruta PremiumSuccess y PremiumError con analytics: true, y se actualizó la ruta PremiumCheckout para usar alias @.